### PR TITLE
Restructure blockchain RPC database

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@
 import os
 from collections import OrderedDict
 import json
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, Response
 from flask_jwt_extended import JWTManager, jwt_required, create_access_token, get_jwt_identity
 import sqlite3
 import logging
@@ -20,16 +20,17 @@ jwt = JWTManager(app)
 
 
 # Create the database table if it doesn't exist
-def create_table_if_not_exist():
-    app.logger.info(f"CREATING database and tables {app.config['DATABASE']}")
+def create_tables_if_not_exist():
+    app.logger.info("CREATING database and tables %s", app.config['DATABASE'])
     conn = sqlite3.connect(app.config['DATABASE'])
     cursor = conn.cursor()
-    cursor.execute('''CREATE TABLE IF NOT EXISTS chains_public_rpcs
-                      (id INTEGER PRIMARY KEY AUTOINCREMENT,
-                       native_id INTEGER NOT NULL,
-                       chain_name TEXT NOT NULL UNIQUE,
-                       urls TEXT NOT NULL,
+    cursor.execute('''CREATE TABLE IF NOT EXISTS chains
+                      (name TEXT PRIMARY KEY UNIQUE NOT NULL,
                        api_class TEXT NOT NULL)''')
+    cursor.execute('''CREATE TABLE IF NOT EXISTS rpc_urls
+                      (url TEXT PRIMARY KEY UNIQUE NOT NULL,
+                       chain_name TEXT NOT NULL,
+                       FOREIGN KEY(chain_name) REFERENCES chains(name))''')
     conn.commit()
     conn.close()
 
@@ -78,185 +79,265 @@ def protected():
     return jsonify(logged_in_as=current_user), 200
 
 
-# Create a new record
-@app.route('/create', methods=['POST'])
-def create_record():
-    # Get the data from the request provided by flask
-    data = request.get_json()
-    # Check that all three entries are present
-    if not all(key in data for key in ('native_id', 'chain_name', 'urls', 'api_class')):
-        return jsonify({'error': 'All three entries are required'}), 400
-    # Info
-    app.logger.info(f'Create from data: {data}')
-    # Extract the data from the request
-    native_id = data['native_id']
-    chain_name = data['chain_name']
-    urls = data['urls']
-    api_class = data['api_class']
-    if not is_valid_api(api_class):
-        return jsonify({'error': {'error': "Invalid api"}}), 500
-    # Serialize the urls list to a JSON string
-    urls_json = json.dumps(urls)
-    if not all(is_valid_url(url) for url in urls):
-        return jsonify({'error': {'error': "Invalid url(s)."}}), 500
-    # Insert the record into the app.config['DATABASE']
+TABLE_CHAINS = 'chains'
+TABLE_RPC_URLS = 'rpc_urls'
+
+
+def insert_into_database(table: str, request_data: dict) -> Response:
     try:
         conn = sqlite3.connect(app.config['DATABASE'])
-        c = conn.cursor()
-        c.execute('INSERT INTO chains_public_rpcs (native_id, chain_name, urls, api_class) VALUES (?, ?, ?, ?)',
-                  (native_id, chain_name, urls_json, api_class))
-        record_id = c.lastrowid
+        cursor = conn.cursor()
+        columns = ', '.join(request_data.keys())
+        placeholders = ':' + ', :'.join(request_data.keys())
+        query = f'INSERT INTO {table} ({columns}) VALUES ({placeholders})'
+        cursor.execute(query, request_data)
+        record_id = cursor.lastrowid  # TODO: remove?
         conn.commit()
         conn.close()
         return jsonify({'message': 'Record created successfully', 'id': record_id}), 201
     except sqlite3.IntegrityError as e:
         conn.rollback()  # Roll back the transaction
         conn.close()
-        # Check the error message to see if the UNIQUE constraint was violated
-        if "UNIQUE constraint failed: chains_public_rpcs.chain_name" in str(e):
-            error_msg = f"Chain name '{chain_name}' already exists."
-        else:
-            error_msg = str(e)
-        return jsonify({'error': error_msg}), 400
+        return jsonify({'error': str(e)}), 400
+    # TODO: refine this exception
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+# Create a new database record
+@app.route('/create/<string:table>', methods=['POST'])
+def create_record(table: str) -> Response:
+    if table not in [TABLE_CHAINS, TABLE_RPC_URLS]:
+        return jsonify({'error': f'unknown table {table}'}), 400
+    # Get the data from the request provided by flask
+    data = request.get_json()
+    app.logger.info('create_record from data: %s', data)
+
+    if table == TABLE_CHAINS:
+        # Check that the correct entries are present
+        if not all(key in data for key in ('name', 'api_class')):
+            return jsonify({'error': 'Both name and api_class entries are required'}), 400
+        # Extract the data from the request
+        values = {
+            'name': data['name'],
+            'api_class': data['api_class']
+        }
+        # Validate the API class
+        if not is_valid_api(values['api_class']):
+            return jsonify({'error': {'error': "Invalid api"}}), 500
+        # Insert the record into the app.config['DATABASE']
+        return insert_into_database(TABLE_CHAINS, values)
+
+    if table == TABLE_RPC_URLS:
+        # Check that the correct entries are present
+        if not all(key in data for key in ('url', 'chain_name')):
+            return jsonify({'error': 'Both url and chain_name entries are required'}), 400
+        # Extract the data from the request
+        values = {
+            'url': data['url'],
+            'chain_name': data['chain_name']
+        }
+        # Validate the url
+        if not is_valid_url(values['url']):
+            return jsonify({'error': {'error': "Invalid url."}}), 500
+        # Insert the record into the app.config['DATABASE']
+        return insert_into_database(TABLE_RPC_URLS, values)
+
+
+SELECT_QUERY_CHAINS = 'SELECT name, api_class FROM chains'
+SELECT_QUERY_RPC_URLS = 'SELECT url, chain_name FROM rpc_urls'
 
 
 # Get all records
-@app.route('/all', methods=['GET'])
-def get_all_records():
+@app.route('/all/<string:table>', methods=['GET'])
+def get_all_records(table: str) -> Response:
+    if table not in [TABLE_CHAINS, TABLE_RPC_URLS]:
+        return jsonify({'error': f'unknown table {table}'}), 400
     conn = sqlite3.connect(app.config['DATABASE'])
     cursor = conn.cursor()
-    cursor.execute('''SELECT id, native_id, chain_name, urls, api_class
-                      FROM chains_public_rpcs''')
+
+    if table == TABLE_CHAINS:
+        cursor.execute(SELECT_QUERY_CHAINS)
+    if table == TABLE_RPC_URLS:
+        cursor.execute(SELECT_QUERY_RPC_URLS)
+
     records = cursor.fetchall()
     conn.close()
     results = []
-    for record in records:
-        results.append({'id': record[0],
-                        'native_id': record[1],
-                        'chain_name': record[2],
-                        'urls': json.loads(record[3]),
-                        'api_class': record[4], })
+
+    if table == TABLE_CHAINS:
+        for record in records:
+            results.append({'name': record[0], 'api_class': record[1]})
+    if table == TABLE_RPC_URLS:
+        for record in records:
+            results.append({'url': record[0], 'chain_name': record[1]})
     return jsonify(results)
 
 
-# Get a specific record by ID
-@app.route('/get/<int:record_id>', methods=['GET'])
-def get_record(record_id):
+# Get a specific chain by chain name
+@app.route('/get_chain_by_name/<string:name>', methods=['GET'])
+def get_chain_by_name(name: str) -> Response:
     conn = sqlite3.connect(app.config['DATABASE'])
     cursor = conn.cursor()
-    cursor.execute('''SELECT id, native_id, chain_name, urls, api_class
-                      FROM chains_public_rpcs
-                      WHERE id = ?''', (record_id,))
+    cursor.execute('SELECT name, api_class FROM chains WHERE name=?', (name,))
     record = cursor.fetchone()
     conn.close()
     if record:
-        return jsonify({'id': record[0],
-                        'native_id': record[1],
-                        'chain_name': record[2],
-                        'urls': json.loads(record[3]),
-                        'api_class': record[4]})
-    else:
-        return jsonify({'error': 'Record not found'}), 404
+        return jsonify({'name': record[0], 'api_class': record[1]})
+    return jsonify({'error': 'Record not found'}), 404
 
 
-# Update an existing record
-@app.route('/update/<int:record_id>', methods=['PUT'])
-def update_record(record_id):
+# TODO: not working due to slashes in the url strings, implement a way around this
+# TODO: after above, verify
+# Get a specific chain by url
+@app.route('/get_chain_by_url/<string:url>', methods=['GET'])
+def get_chain_by_url(url: str) -> Response:
+    conn = sqlite3.connect(app.config['DATABASE'])
+    cursor = conn.cursor()
+    cursor.execute('SELECT url, chain_name FROM rpc_urls WHERE url=?', (url,))
+    url_record = cursor.fetchone()
+    cursor.execute('''SELECT name, api_class
+                      FROM chains
+                      WHERE name = ?''', (url_record[1]))
+    chain_record = cursor.fetchone()
+    conn.close()
+    if chain_record:
+        return jsonify({'name': chain_record[0], 'api_class': chain_record[1]})
+    return jsonify({'error': 'Record not found'}), 404
+
+
+# Get urls for a specific chain
+@app.route('/get_urls/<string:chain_name>', methods=['GET'])
+def get_urls(chain_name: str) -> Response:
+    conn = sqlite3.connect(app.config['DATABASE'])
+    cursor = conn.cursor()
+    cursor.execute('SELECT url, chain_name FROM rpc_urls WHERE chain_name=?', (chain_name,))
+    records = cursor.fetchall()
+    conn.close()
+    urls = []
+    for record in records:
+        urls.append(record[0])
+    if len(urls) > 0:
+        return jsonify(urls)
+    return jsonify({'error': f'No urls found for chain {chain_name}'}), 404
+
+
+# TODO: verify
+# Update an existing url record
+@app.route('/update/<string:url_old>', methods=['PUT'])
+def update_url_record(url_old: str) -> Response:
     try:
-        native_id = request.json['native_id']
+        url_new = request.json['url']
         chain_name = request.json['chain_name']
-        urls = request.json['urls']
-        api_class = request.json['api_class']
     except KeyError as e:
-        return jsonify({'error': 'Missing required parameters'}), 400
-    if not is_valid_api(api_class):
-        return jsonify({'error': {'error': "Invalid api"}}), 500
-    # Make sure urls are OK
-    urls_json = json.dumps(urls)
-    if not all(is_valid_url(url) for url in urls):
-        return jsonify({'error': "Invalid url(s)"}), 500
+        return jsonify({'error': f'Missing required parameters, {e}'}), 400
+    if not is_valid_url(url_new):
+        return jsonify({'error': "Invalid url"}), 500
+
+    conn = sqlite3.connect(app.config['DATABASE'])
+    cursor = conn.cursor()
     try:
-        conn = sqlite3.connect(app.config['DATABASE'])
-        cursor = conn.cursor()
-        cursor.execute('''UPDATE chains_public_rpcs
-                        SET native_id = ?, chain_name = ?, urls = ?, api_class = ?
-                        WHERE id = ?''',
-                       (native_id, chain_name, urls_json, api_class, record_id))
+        cursor.execute('''UPDATE rpc_urls
+                        SET url = ?, chain_name = ?
+                        WHERE url = ?''',
+                       (url_new, chain_name, url_old))
     except sqlite3.IntegrityError as e:
         conn.rollback()  # Roll back the transaction
         conn.close()
-        # Check the error message to see if the UNIQUE constraint was violated
-        if "UNIQUE constraint failed: chains_public_rpcs.chain_name" in str(e):
-            error_msg = f"Chain name '{chain_name}' already exists."
-        else:
-            error_msg = str(e)
-        return jsonify({'error': error_msg}), 400
+        return jsonify({'error': str(e)}), 400
+    # TODO: refine this exception
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
     conn.commit()
     conn.close()
     if cursor.rowcount == 0:
         return jsonify({'error': 'No such record.'})
     else:
-        return jsonify({'id': record_id,
-                        'native_id': native_id,
-                        'chain_name': chain_name,
-                        'urls': urls,
-                        'api_class': api_class})
+        return jsonify({'url': url_new, 'chain_name': chain_name})
 
 
-# Delete a record by ID
-@app.route('/delete/<int:record_id>', methods=['DELETE'])
-def delete_record(record_id):
+# TODO: verify
+# Delete a chain record by name
+@app.route('/delete_chain/<string:name>', methods=['DELETE'])
+def delete_chain_record(name: str) -> Response:
     conn = sqlite3.connect(app.config['DATABASE'])
     cursor = conn.cursor()
-    cursor.execute('''DELETE FROM chains_public_rpcs
-                      WHERE id = ?''', (record_id,))
+    try:
+        cursor.execute('DELETE FROM chains WHERE name=?', (name,))
+    except sqlite3.IntegrityError as e:
+        return jsonify({'error': str(e)}), 400
     conn.commit()
     conn.close()
     return jsonify({'message': 'Record deleted successfully'})
 
 
+# TODO: verify
+# Delete a url record by url
+@app.route('/delete_url/<string:url>', methods=['DELETE'])
+def delete_url_record(url: str) -> Response:
+    conn = sqlite3.connect(app.config['DATABASE'])
+    cursor = conn.cursor()
+    try:
+        cursor.execute('DELETE FROM rpc_urls WHERE url=?', (url,))
+    except sqlite3.IntegrityError as e:
+        return jsonify({'error': str(e)}), 400
+    conn.commit()
+    conn.close()
+    return jsonify({'message': 'Record deleted successfully'})
+
+
+# TODO: verify
+# Delete url records by chain name
+@app.route('/delete_url/<string:chain_name>', methods=['DELETE'])
+def delete_url_records(chain_name: str) -> Response:
+    conn = sqlite3.connect(app.config['DATABASE'])
+    cursor = conn.cursor()
+    try:
+        cursor.execute('DELETE FROM rpc_urls WHERE chain_name=?', (chain_name,))
+    except sqlite3.IntegrityError as e:
+        return jsonify({'error': str(e)}), 400
+    conn.commit()
+    conn.close()
+    return jsonify({'message': 'Records deleted successfully'})
+
+
+# TODO: verify
+# Get all available info on a chain
 @app.route('/chain_info', methods=['GET'])
 def get_chain_info():
     # Get parameters from the request URL
-    chain_name = request.args.get('chain_name')
-    native_id = request.args.get('native_id')
+    name = request.args.get('name')
     # Connect to the app.config['DATABASE']
     conn = sqlite3.connect(app.config['DATABASE'])
-    c = conn.cursor()
+    cursor = conn.cursor()
     # Query the app.config['DATABASE'] based on whether chain name or chain ID was provided
-    if chain_name:
-        c.execute("SELECT * FROM chains_public_rpcs WHERE chain_name=?", (chain_name,))
-    elif native_id:
-        c.execute("SELECT * FROM chains_public_rpcs WHERE native_id=?", (native_id,))
+    if name:
+        cursor.execute("SELECT * FROM chains WHERE name=?", (name,))
     else:
-        return jsonify({'error': 'Missing required parameters'}), 400
-    # Fetch all the rows from the query
-    rows = c.fetchall()
+        return jsonify({'error': 'Missing required parameter "name"'}), 400
+    # Fetch the chain record from the query
+    chain_record = cursor.fetchone()  # TODO: fetchone() should be enough here, right? Only one should exist
     # If no result was found, return an error
-    if not rows:
-        return jsonify({'error': 'Chain not found'}), 404
-    # Convert the urls field from a string to a list
-    result_dicts = []
-    for result in rows:
-        urls = json.loads(result[3])
-        result_dict = {
-            'id': result[0],
-            'native_id': result[1],
-            'chain_name': result[2],
-            'urls': urls
-        }
-        # Use OrderedDict to ensure that 'id' key is first
-        ordered_dict = OrderedDict([('id', result[0])] + list(result_dict.items()))
-        result_dicts.append(ordered_dict)
+    if not chain_record:
+        return jsonify({'error': 'Chain not found'}), 404  # TODO: can this error happen, since we found it in the previous if?
+
+    cursor.execute('''SELECT url, chain_name FROM rpc_urls WHERE chain_name=?''', (name,))
+    url_records = cursor.fetchall()
+    conn.close()
+    urls = []
+    for ur in url_records:
+        urls.append(ur[0])
+    result = {
+        'chain_name': chain_record[0],
+        'api_class': chain_record[1],
+        'urls': urls
+    }
     # Return the chain info as JSON
-    return jsonify(result_dicts), 200
+    return jsonify(result), 200
 
 
 if __name__ == '__main__':
-    create_table_if_not_exist()
+    create_tables_if_not_exist()
     # TODO: add argument parser for things like host?
     app.run(debug=True, host='0.0.0.0')

--- a/db_json_util.py
+++ b/db_json_util.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+
+import requests
+import json
+import argparse
+import sqlite3
+from pathlib import Path
+
+
+DEFAULT_URL = 'http://localhost:5000'
+DEFAULT_FILE = Path.cwd() / 'live_database.db'
+
+TABLE_CHAINS = 'chains'
+TABLE_RPC_URLS = 'rpc_urls'
+
+
+# TODO: define json schemas for database entries
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Import or export JSON data to or from the chain database')
+    parser.add_argument('--api',  action='store_true', help='If the script should operate with the database API endpoint')
+    parser.add_argument('--url', type=str, help='The url for the API of the database', default=DEFAULT_URL)
+    parser.add_argument('--local', action='store_true',  help='If the script should operate with a local database file')
+    parser.add_argument('--db_file', type=str, help='The local database file', default=DEFAULT_FILE)
+
+    parser.add_argument('--add', action='store_true',
+                        help='Import data to the database from the target JSON file. Overwrites existing entries for matching identifiers.')
+    parser.add_argument('--export', action='store_true',
+                        help='Export data from the database to the target JSON file. Note: will overwrite the target JSON files!')
+    parser.add_argument('--json_chains', type=str, help='The JSON file target for "chains"')
+    parser.add_argument('--json_rpc_urls', type=str, help='The JSON file target for "rpc_urls"')
+    args = parser.parse_args()
+
+    if args.api and args.local:
+        raise ValueError('Cannot specify both "api" and "local"')
+    if not any([args.api, args.local]):
+        raise ValueError('Specify either api or local')
+    if args.add and args.export:
+        raise ValueError('Cannot specify both "add" and "export"')
+    if not any([args.add, args.export]):
+        raise ValueError('Specify either add or export')
+    if not all([args.json_chains, args.json_rpc_urls]):
+        raise ValueError('Target JSON files required to run script')
+
+    path_db_file = Path.cwd() / args.db_file
+    path_json_chains = Path.cwd() / args.json_chains
+    path_json_rpc_urls = Path.cwd() / args.json_rpc_urls
+
+    if args.local and not path_db_file.exists():
+        raise FileNotFoundError(f'Database file {args.file} not found')
+
+    if args.api:
+        print('using api database')
+        # TODO: implement
+
+    if args.local:
+        if args.add:
+            print(f'> importing data from {path_json_chains.name} and {path_json_rpc_urls.name}')
+            import_from_json_files(path_json_chains, path_json_rpc_urls, path_db_file)
+            print(f'> data added to {path_db_file.name}')
+        if args.export:
+            print(f'> exporting data from {path_db_file.name}')
+            export_to_json_files(path_json_chains, path_json_rpc_urls, path_db_file)
+            print(f'> data written to {path_json_chains.name} and {path_json_rpc_urls.name}')
+
+
+def import_from_json_files(json_chains: Path, json_rpc_urls: Path, db_file: Path):
+    """
+    Imports data from two JSON file into an SQLite database.
+    Assumes the JSON files has a specific format as defined by XYZ. # TODO: mention the schema when implemented
+    """
+    with open(json_chains, 'r', encoding='utf-8') as f:
+        data_chains = json.load(f)
+    with open(json_rpc_urls, 'r', encoding='utf-8') as f:
+        data_rpc_urls = json.load(f)
+
+    conn = sqlite3.connect(db_file)
+    conn.execute('PRAGMA foreign_keys = ON')
+    cursor = conn.cursor()
+
+    print(data_chains)
+    print(data_rpc_urls)
+
+    for entry in data_chains:
+        name = entry['name']
+        api_class = entry['api_class']
+        query = f'INSERT INTO {TABLE_CHAINS} (name, api_class) VALUES (?, ?)'
+        values = (name, api_class)
+        cursor.execute(query, values)
+
+    for entry in data_rpc_urls:
+        url = entry['url']
+        chain_name = entry['chain_name']
+        query = f'INSERT INTO {TABLE_RPC_URLS} (url, chain_name) VALUES (?, ?)'
+        values = (url, chain_name)
+        try:
+            cursor.execute(query, values)
+        except sqlite3.IntegrityError as e:
+            conn.rollback()  # Roll back the transaction
+            print('Foreign key constraint failed: %s', e)
+
+    conn.commit()
+    conn.close()
+
+
+def export_to_json_files(json_chains: Path, json_rpc_urls: Path, db_file: Path):
+    """
+    Exports data from an SQLite database into two JSON files.
+    The output JSON files has a specific format as defined by XYZ. # TODO: mention the schema when implemented
+    """
+    conn = sqlite3.connect(db_file)
+    conn.execute('PRAGMA foreign_keys = ON')
+    cursor = conn.cursor()
+
+    query_chains = f'SELECT name, api_class FROM {TABLE_CHAINS}'
+    entries_chains = cursor.execute(query_chains).fetchall()
+    data_chains = []
+    for entry in entries_chains:
+        name = entry[0]
+        api_class = entry[1]
+        data_chains.append({'name': name, 'api_class': api_class})
+    with open(json_chains, 'w', encoding='utf-8') as f:
+        json.dump(data_chains, f, ensure_ascii=False, indent=4)
+
+    query_rpc_urls = f'SELECT url, chain_name FROM {TABLE_RPC_URLS}'
+    entries_rpc_urls = cursor.execute(query_rpc_urls).fetchall()
+    data_rpc_urls = []
+    for entry in entries_rpc_urls:
+        url = entry[0]
+        chain_name = entry[1]
+        data_rpc_urls.append({'url': url, 'chain_name': chain_name})
+    with open(json_rpc_urls, 'w', encoding='utf-8') as f:
+        json.dump(data_rpc_urls, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == '__main__':
+    main()

--- a/json/chains.json
+++ b/json/chains.json
@@ -1,0 +1,10 @@
+[
+    {
+        "api_class": "ethereum",
+        "name": "Arbitrum mainnet"
+    },
+    {
+        "api_class": "ethereum",
+        "name": "Ethereum mainnet"
+    }
+]

--- a/json/rpc_urls.json
+++ b/json/rpc_urls.json
@@ -1,0 +1,30 @@
+[
+    {
+        "chain_name": "Arbitrum mainnet",
+        "url": "https://arbitrum-mainnet-archive-rpc-1.dwellir.com"
+    },
+    {
+        "chain_name": "Arbitrum mainnet",
+        "url": "https://arbitrum-mainnet-archive-rpc-2.dwellir.com"
+    },
+    {
+        "chain_name": "Arbitrum mainnet",
+        "url": "https://arb1.arbitrum.io/rpc"
+    },
+    {
+        "chain_name": "Ethereum mainnet",
+        "url": "https://cloudflare-eth.com"
+    },
+    {
+        "chain_name": "Ethereum mainnet",
+        "url": "https://ethereum.publicnode.com"
+    },
+    {
+        "chain_name": "Ethereum mainnet",
+        "url": "https://eth-mainnet-full-rpc-1.dwellir.com"
+    },
+    {
+        "chain_name": "Ethereum mainnet",
+        "url": "https://eth-mainnet-full-rpc-2.dwellir.com"
+    }
+]

--- a/test_api_crud.py
+++ b/test_api_crud.py
@@ -5,7 +5,7 @@ import sqlite3
 import tempfile
 import unittest
 import json
-from app import app, create_table_if_not_exist
+from app import app, create_tables_if_not_exist
 
 
 class CRUDTestCase(unittest.TestCase):
@@ -52,7 +52,7 @@ class CRUDTestCase(unittest.TestCase):
 
     def init_db(self):
         # Use the same create_table as for the live database.
-        create_table_if_not_exist()
+        create_tables_if_not_exist()
 
     def populate_db(self):
         conn = sqlite3.connect(app.config['DATABASE'])


### PR DESCRIPTION
Includes a number of updates:

- Restructures the blockchain RPC database to use two tables; one for the blockchains and one for the URLs, which references the chain table.
- Adds a new script, `db_json_util.py`, intended to replace the pre-existing ones like `add-from-json-file.py` and `add-from-directory-json.py`.
- New way of backuping the database in JSON will be with one file per table instead of one file per blockchain.

To do before ready for review and merge to `master`:
- [ ] Confirm that all endpoints work as expected with the new database design.
- [ ] Adapt the unit tests (`test_api_crud.py`) to the new database design.
- [ ] Add functionality to the DB json util (`db_json_util.py`) to let it add/export over API (first implementation only interacts with a local DB file).